### PR TITLE
Move enum ExtrudeMethod inside MeshTool class to avoid name conflicts

### DIFF
--- a/Assets/Examples/Scripts/MeshTool.cs
+++ b/Assets/Examples/Scripts/MeshTool.cs
@@ -1,15 +1,15 @@
 using UnityEngine;
 using System.Collections.Generic;
 
-public enum ExtrudeMethod
-{
-    Vertical,
-    MeshNormal
-}
-
 // Manipulation tool for displacing the vertices in a list of meshes
 public class MeshTool : MonoBehaviour
 {
+    public enum ExtrudeMethod
+    {
+        Vertical,
+        MeshNormal
+    }
+    
     public List<MeshFilter> m_Filters = new List<MeshFilter>();
     public float m_Radius = 1.5f;
     public float m_Power = 2.0f;


### PR DESCRIPTION
ProBuilder (a Unity plugin) also defines `ExtrudeMethod` inside the `ProBuilder2.Common` namespace, but since `MeshTool` is declaring it outside a namespace or class it's throwing errors when present in the same project.

I can add `ProBuilder2.Common.ExtrudeMethod` to all the occurrences in ProBuilder, but I just wanted to quickly check if it would be acceptable to move the `ExtrudeMethod` enum definition inside the MeshTools body.


