### PR TITLE
NavMeshSurface - support for tree colliders

### DIFF
--- a/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
+++ b/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
@@ -318,7 +318,7 @@ namespace UnityEngine.AI
                 foreach (var collider in proto.GetComponentsInChildren<Collider>())
                 {
                     // Take into account layer mask
-                    if ((collider.gameObject.layer & layerMask) != 0)
+                    if (((1 << collider.gameObject.layer) & layerMask) != 0)
                     {
                         Matrix4x4 colliderMatrix = proto.transform.worldToLocalMatrix * collider.transform.localToWorldMatrix;
 

--- a/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
+++ b/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
@@ -287,7 +287,7 @@ namespace UnityEngine.AI
                 TerrainData terrain;
                 if (sources[i].sourceObject.TryCast(out terrain))
                 {
-                    CollectTrees(sources[i].component, terrain, sources[i].transform, m_LayerMask, m_UseGeometry, 1, sources);
+                    CollectTrees(sources[i].component, terrain, sources[i].transform, m_LayerMask, 1, sources);
                 }
             }
 
@@ -302,7 +302,7 @@ namespace UnityEngine.AI
             return sources;
         }
 
-        private static void CollectTrees(Component owner, TerrainData terrain, Matrix4x4 transform, int layerMask, NavMeshCollectGeometry geometry, int area, List<NavMeshBuildSource> sources)
+        private static void CollectTrees(Component owner, TerrainData terrain, Matrix4x4 transform, int layerMask, int area, List<NavMeshBuildSource> sources)
         {
             var size = terrain.size;
 
@@ -317,15 +317,19 @@ namespace UnityEngine.AI
 
                 foreach (var collider in proto.GetComponentsInChildren<Collider>())
                 {
-                    Matrix4x4 colliderMatrix = proto.transform.worldToLocalMatrix * collider.transform.localToWorldMatrix;
-
-                    NavMeshBuildSource src = new NavMeshBuildSource();
-                    src.area = area;
-                    src.component = owner;
-                    src.sourceObject = null;
-                    if (SetCollider(collider, transform * treeLocal * colliderMatrix, ref src))
+                    // Take into account layer mask
+                    if ((collider.gameObject.layer & layerMask) != 0)
                     {
-                        sources.Add(src);
+                        Matrix4x4 colliderMatrix = proto.transform.worldToLocalMatrix * collider.transform.localToWorldMatrix;
+
+                        NavMeshBuildSource src = new NavMeshBuildSource();
+                        src.area = area;
+                        src.component = owner;
+                        src.sourceObject = null;
+                        if (SetCollider(collider, transform * treeLocal * colliderMatrix, ref src))
+                        {
+                            sources.Add(src);
+                        }
                     }
                 }
             }

--- a/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
+++ b/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace UnityEngine.AI
@@ -281,6 +282,15 @@ namespace UnityEngine.AI
                 NavMeshBuilder.CollectSources(worldBounds, m_LayerMask, m_UseGeometry, m_DefaultArea, markups, sources);
             }
 
+            for (int i = 0; i < sources.Count; i++)
+            {
+                TerrainData terrain;
+                if (sources[i].sourceObject.TryCast(out terrain))
+                {
+                    CollectTrees(sources[i].component, terrain, sources[i].transform, m_LayerMask, m_UseGeometry, 1, sources);
+                }
+            }
+
             if (m_IgnoreNavMeshAgent)
                 sources.RemoveAll((x) => (x.component != null && x.component.gameObject.GetComponent<NavMeshAgent>() != null));
 
@@ -290,6 +300,90 @@ namespace UnityEngine.AI
             AppendModifierVolumes(ref sources);
 
             return sources;
+        }
+
+        private static void CollectTrees(Component owner, TerrainData terrain, Matrix4x4 transform, int layerMask, NavMeshCollectGeometry geometry, int area, List<NavMeshBuildSource> sources)
+        {
+            var size = terrain.size;
+
+            foreach (var tree in terrain.treeInstances)
+            {
+                var proto = terrain.treePrototypes[tree.prototypeIndex].prefab;
+                var pos = Vector3.Scale(tree.position, size);
+                var rot = Quaternion.AngleAxis(Mathf.Rad2Deg * tree.rotation, Vector3.up);
+                var scale = new Vector3(tree.widthScale, tree.heightScale, tree.widthScale);
+                scale = Vector3.one;
+                var treeLocal = Matrix4x4.TRS(pos, rot, scale);
+
+                foreach (var collider in proto.GetComponentsInChildren<Collider>())
+                {
+                    Matrix4x4 colliderMatrix = proto.transform.worldToLocalMatrix * collider.transform.localToWorldMatrix;
+
+                    NavMeshBuildSource src = new NavMeshBuildSource();
+                    src.area = area;
+                    src.component = owner;
+                    src.sourceObject = null;
+                    if (SetCollider(collider, transform * treeLocal * colliderMatrix, ref src))
+                    {
+                        sources.Add(src);
+                    }
+                }
+            }
+        }
+
+        private static bool SetCollider(Collider collider, Matrix4x4 transform, ref NavMeshBuildSource source)
+        {
+            BoxCollider box;
+            SphereCollider sphere;
+            CapsuleCollider capsule;
+            MeshCollider mesh;
+            if (collider.TryCast(out sphere))
+            {
+                // Size is supposed to be radius, but it's actually diameter
+                source.shape = NavMeshBuildSourceShape.Sphere;
+                source.size = sphere.radius * 2 * Vector3.one;
+                source.transform = transform * Matrix4x4.Translate(sphere.center);
+                return true;
+            }
+            else if (collider.TryCast(out capsule))
+            {
+                // Capsule is expected to be in y-axis
+                var rot = Matrix4x4.identity;
+                if (capsule.direction == 0)
+                {
+                    rot = Matrix4x4.Rotate(Quaternion.AngleAxis(90, Vector3.forward));
+                }
+                else if (capsule.direction == 2)
+                {
+                    rot = Matrix4x4.Rotate(Quaternion.AngleAxis(90, Vector3.right));
+                }
+
+                // Size is supposed to be (radius, height, radius), but it's actually diameter instead of radius
+                source.shape = NavMeshBuildSourceShape.Capsule;
+                source.size = new Vector3(capsule.radius * 2, capsule.height, capsule.radius * 2);
+                source.transform = transform * Matrix4x4.Translate(capsule.center) * rot;
+                return true;
+            }
+            else if (collider.TryCast(out box))
+            {
+                source.shape = NavMeshBuildSourceShape.Box;
+                source.size = box.size;
+                source.transform = transform * Matrix4x4.Translate(box.center);
+                return true;
+            }
+            else if (collider.TryCast(out mesh))
+            {
+                source.shape = NavMeshBuildSourceShape.Mesh;
+                source.size = Vector3.one;
+                source.transform = transform;
+                source.sourceObject = mesh.sharedMesh;
+                return true;
+            }
+            else
+            {
+                Debug.LogWarning("NavMeshSource tree collider not supported: " + collider.GetType().Name);
+                return false;
+            }
         }
 
         static Vector3 Abs(Vector3 v)
@@ -319,18 +413,18 @@ namespace UnityEngine.AI
                 switch (src.shape)
                 {
                     case NavMeshBuildSourceShape.Mesh:
-                    {
-                        var m = src.sourceObject as Mesh;
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, m.bounds));
-                        break;
-                    }
+                        {
+                            var m = src.sourceObject as Mesh;
+                            result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, m.bounds));
+                            break;
+                        }
                     case NavMeshBuildSourceShape.Terrain:
-                    {
-                        // Terrain pivot is lower/left corner - shift bounds accordingly
-                        var t = src.sourceObject as TerrainData;
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * t.size, t.size)));
-                        break;
-                    }
+                        {
+                            // Terrain pivot is lower/left corner - shift bounds accordingly
+                            var t = src.sourceObject as TerrainData;
+                            result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * t.size, t.size)));
+                            break;
+                        }
                     case NavMeshBuildSourceShape.Box:
                     case NavMeshBuildSourceShape.Sphere:
                     case NavMeshBuildSourceShape.Capsule:

--- a/Assets/NavMeshComponents/Scripts/ObjectExtensions.cs
+++ b/Assets/NavMeshComponents/Scripts/ObjectExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public static class ObjectExtensions
+{
+    public static bool TryCast<TIn, TOut>(this TIn obj, out TOut result)
+        where TIn : class
+        where TOut : class
+    {
+        result = obj as TOut;
+        return result != null;
+    }
+}

--- a/Assets/NavMeshComponents/Scripts/ObjectExtensions.cs.meta
+++ b/Assets/NavMeshComponents/Scripts/ObjectExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b458972556566914eb7c92421c9f9b89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
After sources are collected by calling `NavMeshBuilder.CollectSources`, go through and add tree colliders for each `TerrainCollider` encountered.

Supported tree colliders are: Sphere, Capsule, Box, Mesh.

Tree colliders are added with hard-coded area `Non-walkable`.
`NavMeshModifier` on trees is not supported (yet).
`NavMeshModifierVolume` should work as usual, even on trees.

In future I'd like to support `NavMeshModifier` and use default area instead of hard-coded `Non-walkable`

Resolves #30 