### PR TITLE
Add option to ignore trigger colliders when collecting sources

### DIFF
--- a/Assets/NavMeshComponents/Editor/NavMeshSurfaceEditor.cs
+++ b/Assets/NavMeshComponents/Editor/NavMeshSurfaceEditor.cs
@@ -27,6 +27,7 @@ namespace UnityEditor.AI
         SerializedProperty m_Size;
         SerializedProperty m_TileSize;
         SerializedProperty m_UseGeometry;
+        SerializedProperty m_IgnoreTriggerColliders;
         SerializedProperty m_VoxelSize;
 
 #if NAVMESHCOMPONENTS_SHOW_NAVMESHDATA_REF
@@ -73,6 +74,7 @@ namespace UnityEditor.AI
             m_Size = serializedObject.FindProperty("m_Size");
             m_TileSize = serializedObject.FindProperty("m_TileSize");
             m_UseGeometry = serializedObject.FindProperty("m_UseGeometry");
+            m_IgnoreTriggerColliders = serializedObject.FindProperty("m_IgnoreTriggerColliders");
             m_VoxelSize = serializedObject.FindProperty("m_VoxelSize");
 
 #if NAVMESHCOMPONENTS_SHOW_NAVMESHDATA_REF
@@ -132,6 +134,12 @@ namespace UnityEditor.AI
 
             EditorGUILayout.PropertyField(m_LayerMask, s_Styles.m_LayerMask);
             EditorGUILayout.PropertyField(m_UseGeometry);
+            if ((NavMeshCollectGeometry)m_UseGeometry.enumValueIndex == NavMeshCollectGeometry.PhysicsColliders)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(m_IgnoreTriggerColliders);
+                EditorGUI.indentLevel--;
+            }
 
             EditorGUILayout.Space();
 

--- a/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
+++ b/Assets/NavMeshComponents/Scripts/NavMeshSurface.cs
@@ -56,6 +56,10 @@ namespace UnityEngine.AI
         public bool ignoreNavMeshObstacle { get { return m_IgnoreNavMeshObstacle; } set { m_IgnoreNavMeshObstacle = value; } }
 
         [SerializeField]
+        bool m_IgnoreTriggerColliders = false;
+        public bool ignoreTriggerColliders { get { return m_IgnoreTriggerColliders; } set { m_IgnoreTriggerColliders = value; } }
+
+        [SerializeField]
         bool m_OverrideTileSize;
         public bool overrideTileSize { get { return m_OverrideTileSize; } set { m_OverrideTileSize = value; } }
         [SerializeField]
@@ -345,6 +349,9 @@ namespace UnityEngine.AI
 
             if (m_IgnoreNavMeshObstacle)
                 sources.RemoveAll((x) => (x.component != null && x.component.gameObject.GetComponent<NavMeshObstacle>() != null));
+
+            if (m_UseGeometry == NavMeshCollectGeometry.PhysicsColliders && m_IgnoreTriggerColliders)
+                sources.RemoveAll((x) => (x.component != null && x.component.gameObject.TryGetComponent(out Collider col) && col.isTrigger));
 
             AppendModifierVolumes(ref sources);
 


### PR DESCRIPTION
When using Physics Colliders as the geometry source for collecting NavMesh surfaces, there is no distinction between regular and trigger colliders.

This can have the unforeseen effect of creating surfaces where they are not really desired, possibly blocking building entrances / hallways etc.

This PR adds a `m_IgnoreTriggerColliders` bool that, when enabled, excludes trigger colliders from being used in the NavMeshSurface components. This bool will be shown only when Use Geometry is set to Physics Colliders.
