### PR TITLE
Fix disabling a NavMeshLink component when gizmo are displayed

### DIFF
--- a/Assets/NavMeshComponents/Editor/NavMeshLinkEditor.cs
+++ b/Assets/NavMeshComponents/Editor/NavMeshLinkEditor.cs
@@ -138,7 +138,7 @@ namespace UnityEditor.AI
         [DrawGizmo(GizmoType.Selected | GizmoType.Active | GizmoType.Pickable)]
         static void RenderBoxGizmo(NavMeshLink navLink, GizmoType gizmoType)
         {
-            if (!EditorApplication.isPlaying)
+            if (!EditorApplication.isPlaying && navLink.isActiveAndEnabled)
                 navLink.UpdateLink();
 
             var color = s_HandleColor;


### PR DESCRIPTION
### Purpose of this PR
Fix: Disabling a NavMeshLink component in the Editor does not correctly remove the link from the NavMesh system

### Testing status
Manual testing:
Enabling/disabling a NavMeshLink component with Gizmo don't display errors in the console anymore

### Technical / Halo risk
* Tech Risk: 1
* Halo Risk: 1
